### PR TITLE
Fix dead TaskMetadata.mcp_log_dir ref and outdated CLI name in prompt

### DIFF
--- a/prompts/prompt_complete_file.txt
+++ b/prompts/prompt_complete_file.txt
@@ -1,9 +1,9 @@
 Complete the target Lean theorem file, making it sorry-free and ensuring it compiles without errors.
 
-Use `python skills/cli/diagnostic.py FILE` to verify the file. Errors mean `"has_error": true` or severity `"error"` in the response.
+Use `python skills/cli/lean_check.py FILE` to verify the file. Errors mean `"has_error": true` or severity `"error"` in the response.
 
 IMPORTANT:
-- Verify the file again after each update using `python skills/cli/diagnostic.py`.
+- Verify the file again after each update using `python skills/cli/lean_check.py`.
 - You may add helper lemmas, but do not create new axioms.
 
 Tips:
@@ -21,4 +21,4 @@ where {reason} is:
 - LIMIT — if stopped due to limits or there are still sorries/errors
 - COMPLETE — only if the file is sorry-free AND compiles without errors
 
-IMPORTANT: Use `python skills/cli/diagnostic.py` to verify, do not use `lake build`.
+IMPORTANT: Use `python skills/cli/lean_check.py` to verify, do not use `lake build`.

--- a/scripts/task.py
+++ b/scripts/task.py
@@ -69,8 +69,6 @@ class TaskMetadata:
             self.prompt_file = Path(self.prompt_file).resolve()
         if self.result_dir:
             self.result_dir = Path(self.result_dir).resolve()
-        if self.mcp_log_dir:
-            self.mcp_log_dir = Path(self.mcp_log_dir).resolve()
         if self.safe_verify_path:
             self.safe_verify_path = Path(self.safe_verify_path).resolve()
         if self.safe_verify_cwd:


### PR DESCRIPTION
## Summary

Two small fixes that surfaced while running the autosearch pipeline end-to-end on a Minif2f problem.

### 1. `scripts/task.py` — `AttributeError: 'TaskMetadata' object has no attribute 'mcp_log_dir'`

In fd4100b (\"Integrate autosearch prompt set and per-task CLI log plumbing\") the `mcp_log_dir` / `mcp_log_name` fields were removed from `TaskMetadata`, and the corresponding normalize block in `__post_init__` was removed. During a later merge with the `safe_verify` branch, the normalize line `if self.mcp_log_dir: self.mcp_log_dir = Path(self.mcp_log_dir).resolve()` was reintroduced — but the field itself was not, so every `TaskMetadata(...)` construction now crashes.

Repro (on `main`, before this fix):

```bash
python -m scripts.run_claude run path/to/file.lean --prompt-file prompts/prompt_complete_file.txt
# AttributeError: 'TaskMetadata' object has no attribute 'mcp_log_dir'
```

This blocks `run` / `batch` / `from-folder` — i.e., the entire `scripts/run_claude` CLI.

### 2. `prompts/prompt_complete_file.txt` — references a script that does not exist

The prompt instructs the agent three times to `python skills/cli/diagnostic.py FILE`, but the actual file is `skills/cli/lean_check.py` (there is no `diagnostic.py` in `skills/cli/`). The Claude agent usually adapts, but a strict reading fails and the instruction is misleading.

> Side note (not changed here): the same prompt also says \"Errors mean `\"has_error\": true`\" — `lean_check.py` actually returns `okay: false` (no `has_error` key). I left that alone to keep the diff focused; happy to fix in a follow-up if maintainers want.

## Test plan

- [x] Reproduced #1 by running `python -m scripts.run_claude run ...` on `main` — confirmed AttributeError
- [x] Ran the same command after the fix on a Minif2f problem (`algebra_sqineq_2atp2bpge2ab`) — agent completed in 1 round (`nlinarith [sq_nonneg (a - b)]`), `lean_check.py` verified, exit 0
- [x] `grep -rn 'mcp_log_dir' scripts/` returns no hits after the fix
- [x] `grep -rn 'skills/cli/diagnostic' .` returns no hits after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)