### PR TITLE
[codex] Remove stale mcp_log_dir reference

### DIFF
--- a/scripts/task.py
+++ b/scripts/task.py
@@ -69,8 +69,6 @@ class TaskMetadata:
             self.prompt_file = Path(self.prompt_file).resolve()
         if self.result_dir:
             self.result_dir = Path(self.result_dir).resolve()
-        if self.mcp_log_dir:
-            self.mcp_log_dir = Path(self.mcp_log_dir).resolve()
         if self.safe_verify_path:
             self.safe_verify_path = Path(self.safe_verify_path).resolve()
         if self.safe_verify_cwd:


### PR DESCRIPTION
## Summary
Removes a stale `mcp_log_dir` reference from `TaskMetadata.__post_init__`.

## Root Cause
`mcp_log_dir` existed in the initial MCP log implementation, but commit `fd4100b` migrated logging to per-task CLI logs via `CLI_LOG_PATH`. That commit removed the `mcp_log_dir` / `mcp_log_name` dataclass fields, serialization fields, config examples, and MCP stats plumbing, but left one normalization block behind in `__post_init__`.

Because the dataclass no longer defines `mcp_log_dir`, constructing any `TaskMetadata` currently raises:

```text
AttributeError: 'TaskMetadata' object has no attribute 'mcp_log_dir'
```

## Impact
This fixes task construction for `run`, `batch`, `from-folder`, and LiveProveBench runs. It does not change the current logging interface; per-task logs continue to use `CLI_LOG_PATH=<result_dir>/<task_id>/cli.log`.

## Validation
- Confirmed history: `mcp_log_dir` existed in `32825eb` and was removed by the CLI log migration in `fd4100b`.
- Confirmed current references before the fix: `git grep` showed `mcp_log_dir` only in the stale `scripts/task.py` block.
- Ran constructor smoke test.
- Ran script parse check.
