### PR TITLE
Fix statement restore integrity and attributed theorem tracking

### DIFF
--- a/scripts/extract_sublemmas.py
+++ b/scripts/extract_sublemmas.py
@@ -5,6 +5,16 @@ from typing import Any
 DOT_KEYS = [".", "·"]
 DOT_KEYS_TUPLE = (".", "·")
 
+# Leading modifiers that may precede theorem/lemma (and attributes).
+_DECL_MODIFIERS = (
+    "private",
+    "protected",
+    "public",
+    "noncomputable",
+    "unsafe",
+    "partial",
+)
+
 
 # ====================================================
 # parser
@@ -52,6 +62,35 @@ class LeanCodeParser:
 
     def get_indent(self, line: str) -> int:
         return len(line) - len(line.lstrip(" "))
+
+    @staticmethod
+    def strip_leading_attrs_and_modifiers(line: str) -> str:
+        """
+        Strip leading `@[...]` attributes and declaration modifiers so the
+        first token is the real keyword (theorem / lemma / def / ...).
+
+        Examples:
+            '@[simp] theorem foo : True'  -> 'theorem foo : True'
+            'private theorem bar : True'  -> 'theorem bar : True'
+            '@[simp] private noncomputable theorem baz' -> 'theorem baz'
+        """
+        s = line.lstrip()
+        # Drop one or more leading attribute blocks: @[...]
+        while s.startswith("@"):
+            # Find matching ']' for the attribute list (no nested brackets in attrs)
+            end = s.find("]")
+            if end < 0:
+                break
+            s = s[end + 1 :].lstrip()
+        # Drop known modifiers (may be stacked)
+        while True:
+            tokens = s.split(None, 1)
+            if not tokens or tokens[0] not in _DECL_MODIFIERS:
+                break
+            s = tokens[1] if len(tokens) > 1 else ""
+        # Preserve original indent of the declaration line
+        indent = len(line) - len(line.lstrip(" "))
+        return (" " * indent + s) if s else line
 
     def extract_headers(self) -> dict:
         """
@@ -325,12 +364,18 @@ class LeanCodeParser:
         if start_line_index >= len(self.cleaned_lines):
             return None
 
-        start_line = self.cleaned_lines[start_line_index]
-        key = start_line.split()[0]
+        raw_start_line = self.cleaned_lines[start_line_index]
+        # Strip @[...] / private / protected / ... so `@[simp] theorem` is found
+        start_line = self.strip_leading_attrs_and_modifiers(raw_start_line)
+        tokens = start_line.split()
+        if not tokens:
+            return None
+        key = tokens[0]
         if key not in keys:
             return None
 
-        start_indent = self.get_indent(start_line)
+        start_indent = self.get_indent(raw_start_line)
+        # Keep the stripped form so name/statement parsing sees `theorem ...`
         block_lines = [start_line]
         i = start_line_index + 1
         while i < len(self.cleaned_lines):

--- a/scripts/statement_tracker.py
+++ b/scripts/statement_tracker.py
@@ -194,73 +194,33 @@ class StatementTracker:
                 print(f"[info] Restored file {f}")
                 restored_files.add(f)
         
-        # Now restore the specific statement changes for each file
-        # Skip files that were restored (they already have all statements)
+        # Restore modified/removed statements by rewriting the file from the
+        # captured original bytes. Replacing LeanCodeParser "cleaned" block
+        # text into the on-disk file is a silent no-op whenever comments,
+        # blank lines, or `:=` spacing differ from the cleaned form — which
+        # is the common MiniF2f / agent-edited case. Full-file restore is
+        # already used for deleted files above; use it for integrity too.
         for f, file_changes in changes_by_file.items():
-            # Skip if this file was deleted and restored
             if f in restored_files:
                 continue
-            
-            if not f.exists():
+
+            initial_content = self.initial_file_contents.get(f)
+            if not initial_content:
                 continue
-                
-            initial_statements = self.initial_snapshots.get(f, {})
-            initial_content = self.initial_file_contents.get(f, "")
-            
-            if not initial_statements or not initial_content:
+
+            relevant = [c for c in file_changes if c.change_type in ("modified", "removed")]
+            if not relevant:
                 continue
-            
-            current_content = f.read_text(encoding="utf-8")
-            new_content = current_content
-            
-            # Parse current content to find blocks
-            parser = LeanCodeParser(current_content)
-            current_blocks = parser.extract_all_blocks(keys=["theorem", "lemma"], allow_overlap=False)
-            
-            # Build a map of current theorem/lemma names to their block text
-            current_block_map = {}
-            for block in current_blocks:
-                name = block.get("info", {}).get("name")
-                if name:
-                    block_text = "\n".join(block.get("lines", []))
-                    current_block_map[name] = block_text
-            
-            for change in file_changes:
-                if change.change_type == "removed":
-                    # Statement was removed, need to restore it
-                    if change.name in initial_statements:
-                        original_stmt = initial_statements[change.name]
-                        # Add the statement with a sorry proof
-                        new_content = new_content + "\n\n" + original_stmt + " := by sorry"
-                        print(f"[info] Restored removed statement '{change.name}' in {f}")
-                
-                elif change.change_type == "modified":
-                    # Statement was modified, restore to original
-                    if change.name in initial_statements and change.name in current_block_map:
-                        original_stmt = initial_statements[change.name]
-                        current_block_text = current_block_map[change.name]
-                        
-                        # The current block includes the proof, we need to replace just the statement part
-                        # Get the statement from info
-                        parser_orig = LeanCodeParser(initial_content)
-                        orig_blocks = parser_orig.extract_all_blocks(keys=["theorem", "lemma"], allow_overlap=False)
-                        
-                        # Find the original block
-                        orig_block_text = None
-                        for block in orig_blocks:
-                            if block.get("info", {}).get("name") == change.name:
-                                orig_block_text = "\n".join(block.get("lines", []))
-                                break
-                        
-                        if orig_block_text:
-                            # Replace the current block with the original block
-                            new_content = new_content.replace(current_block_text, orig_block_text)
-                            print(f"[info] Restored modified statement '{change.name}' in {f}")
-            
-            # Write back if content changed
-            if new_content != current_content:
-                f.write_text(new_content, encoding="utf-8")
-                print(f"[info] Updated {f} with restored statements")
+
+            current_content = f.read_text(encoding="utf-8") if f.exists() else ""
+            if current_content == initial_content:
+                print(f"[info] {f} already matches initial content; nothing to restore")
+                continue
+
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(initial_content, encoding="utf-8")
+            names = ", ".join(c.name for c in relevant)
+            print(f"[info] Restored {f} to initial content (statements: {names})")
 
 
 def extract_claude_usage(claude_result: Optional[dict]) -> Optional[dict]:


### PR DESCRIPTION
## Summary
- Statement restore previously replaced LeanCodeParser *cleaned* block text into the on-disk file. When the source had blank lines, `:=` spacing differences, or comments, that string was not present, so restore printed "Restored" (or wrote nothing) and left a weakened goal in place — an agent could change `P` to `True`, get a sorry-free compile, and still look successful under `on_statement_change=warn`.
- `@[simp] theorem` / `private theorem` / stacked modifiers were invisible to the tracker (`split()[0]` was `@[simp]` or `private`), so attributed/private goals could be rewritten with no warn/error/restore at all.
- Fix: strip leading attributes and modifiers before keyword detection; restore modified/removed statements by rewriting the file from the captured original bytes (same path already used for deleted files). Only report restore when bytes actually change.

## Evidence
Reproduced on current main before the fix:
- blank-line proof body: restore claimed success, file bytes unchanged, `True` still present
- `@[simp] theorem foo` / `private theorem bar`: `extract_statements_from_file` returned `{}`
After the fix, the same cases restore exact original bytes and detect attributed mutations.

## Test plan
- [x] Local repro of silent no-op restore (blank lines / `:=` spacing) before fix; assert exact byte restore after
- [x] Local repro of empty extract for `@[simp]` / `private` / stacked modifiers; assert names tracked and mutations detected
- [x] Cheat pattern (helper lemma + weakened main): restore returns exact original file, helper wiped
- [ ] CI / maintainer review of eval impact on MiniF2f-style runs with `on_statement_change=warn`


Made with [Cursor](https://cursor.com)