### PR TITLE
Fail task success when SafeVerify rejects a COMPLETE proof

### DIFF
--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -568,6 +568,12 @@ def run_task(task: TaskMetadata) -> TaskResult:
                     print(f"[warn] SafeVerify error: {safe_verify_result.error_message}")
                 if safe_verify_result.output.strip():
                     print(safe_verify_result.output)
+                # SafeVerify is the kernel-level integrity gate: a failed check must
+                # flip the task outcome. Leaving success=True on FAILED would report
+                # false positives in result.json / LiveProveBench summary.csv.
+                if safe_verify_result.ran and not safe_verify_result.success:
+                    end_reason = "SAFE_VERIFY_FAILED"
+                    print(f"[error] SafeVerify failed; marking task unsuccessful")
             else:
                 # Proof didn't compile: skip SafeVerify, just clean up snapshot
                 print(f"\n[info] SafeVerify: skipped (end_reason={end_reason}, proof did not compile)")


### PR DESCRIPTION
## Summary
- When `--safe-verify-path` is set and the agent reaches `COMPLETE`, SafeVerify was only logged under a nested field. `TaskResult.success` stayed `true` whenever `end_reason == "COMPLETE"`, including when the kernel check failed.
- That makes false positives in `result.json` and LiveProveBench `summary.csv` — SafeVerify exists specifically to catch proofs that compile but do not replay against the original target.
- On a failed SafeVerify run, set `end_reason = "SAFE_VERIFY_FAILED"` so `success` becomes false. Passed / skipped paths unchanged.

## Test plan
- [x] Confirmed on main that `success = end_reason == "COMPLETE"` runs after the SafeVerify block and ignores `safe_verify_result.success`
- [x] After the change, `SAFE_VERIFY_FAILED` is assigned before that success line when `safe_verify_result.ran and not safe_verify_result.success`
- [ ] Maintainer: run a COMPLETE file task with a known SafeVerify reject and confirm `success: false` / exit non-zero in the batch driver


Made with [Cursor](https://cursor.com)