### PR TITLE
Make Lean checks severity-based and sorry-free for COMPLETE

### DIFF
--- a/scripts/lean_checker.py
+++ b/scripts/lean_checker.py
@@ -2,15 +2,36 @@
 Lean file checking utilities.
 """
 
+import re
 import subprocess
 from pathlib import Path
 from typing import List, Tuple
 from multiprocessing import Pool, cpu_count
 
+# Match Lean diagnostic headers: path:line:col: severity: message
+DIAG_RE = re.compile(
+    r"^(?P<file>.+?):(?P<line>\d+):(?P<col>\d+):\s*(?P<sev>error|warning|info)(?:\([^)]*\))?:\s*(?P<msg>.+)",
+    re.MULTILINE,
+)
+
+# Skip Lake package / VCS trees when scanning a project root.
+_SKIP_DIR_NAMES = {".lake", "lake-packages", ".git"}
+
+# Lean sorry warnings that mean the goal is not fully proven.
+_SORRY_WARNING_MARKERS = (
+    "declaration uses 'sorry'",
+    'declaration uses "sorry"',
+    "uses 'sorry'",
+    'uses "sorry"',
+)
+
 
 def find_lean_files(folder_path: str | Path) -> List[Path]:
     """
     Recursively find all .lean files in a folder.
+
+    Skips `.lake/`, `lake-packages/`, and `.git/` trees so a Lake project
+    root does not fan out into Mathlib / dependency sources after `lake build`.
 
     Args:
         folder_path: Path to the folder to search
@@ -27,8 +48,11 @@ def find_lean_files(folder_path: str | Path) -> List[Path]:
 
     lean_files = []
     for file_path in folder.rglob("*.lean"):
-        if file_path.is_file():
-            lean_files.append(file_path)
+        if not file_path.is_file():
+            continue
+        if any(part in _SKIP_DIR_NAMES for part in file_path.parts):
+            continue
+        lean_files.append(file_path)
 
     return sorted(lean_files)
 
@@ -51,6 +75,36 @@ def find_lean_project_root(file_path: Path) -> Path:
         current = current.parent
     # If not found, return file's parent directory
     return file_path.parent if file_path.is_file() else file_path
+
+
+def classify_lean_output(stdout: str, stderr: str, returncode: int) -> Tuple[bool, bool]:
+    """
+    Classify `lake env lean` output using diagnostic severities.
+
+    Avoids brittle substring checks (`"error" in text`) that false-positive on
+    identifiers like `errorMsg` or paths containing the word error, and that
+    false-positive sorry on any mention of the tactic name outside a warning.
+    """
+    combined = f"{stdout}\n{stderr}"
+    has_error = returncode != 0
+    has_sorry_warning = False
+
+    for match in DIAG_RE.finditer(combined):
+        sev = match.group("sev")
+        msg = match.group("msg").lower()
+        if sev == "error":
+            has_error = True
+        elif sev == "warning" and any(m in msg for m in _SORRY_WARNING_MARKERS):
+            has_sorry_warning = True
+        elif sev == "warning" and "sorry" in msg and "declaration uses" in msg:
+            has_sorry_warning = True
+
+    # Fallback: unsolved goals are errors in Lean, but some older toolchains
+    # may surface residual sorry only as a warning without the exact phrase.
+    if not has_sorry_warning and "declaration uses 'sorry'" in combined.lower():
+        has_sorry_warning = True
+
+    return has_error, has_sorry_warning
 
 
 def check_lean_file(file_path: Path) -> Tuple[bool, bool, str, str]:
@@ -78,17 +132,9 @@ def check_lean_file(file_path: Path) -> Tuple[bool, bool, str, str]:
 
         stdout = result.stdout
         stderr = result.stderr
-
-        # Check for errors
-        has_error = (
-            "error" in stdout.lower()
-            or "error" in stderr.lower()
-            or result.returncode != 0
+        has_error, has_sorry_warning = classify_lean_output(
+            stdout, stderr, result.returncode
         )
-
-        # Check for sorry warnings
-        has_sorry_warning = "sorry" in stdout.lower() or "sorry" in stderr.lower()
-
         return has_error, has_sorry_warning, stdout, stderr
 
     except subprocess.TimeoutExpired:

--- a/skills/cli/lean_check.py
+++ b/skills/cli/lean_check.py
@@ -77,6 +77,29 @@ def extract_failed_declarations(messages: list[dict]) -> list[str]:
     return sorted(failed)
 
 
+_SORRY_WARNING_MARKERS = (
+    "declaration uses 'sorry'",
+    'declaration uses "sorry"',
+    "uses 'sorry'",
+    'uses "sorry"',
+)
+
+
+def has_sorry_warning(messages: list[dict], combined: str = "") -> bool:
+    """True when Lean reports that a declaration still uses sorry."""
+    for msg in messages:
+        if msg["severity"] != "warning":
+            continue
+        data = msg["data"].lower()
+        if any(m in data for m in _SORRY_WARNING_MARKERS):
+            return True
+        if "sorry" in data and "declaration uses" in data:
+            return True
+    if "declaration uses 'sorry'" in combined.lower():
+        return True
+    return False
+
+
 def check(file_path: Path, timeout: int = 120) -> dict:
     """Run `lake env lean` on a file and return axle-compatible result."""
     project_root = find_project_root(file_path)
@@ -92,12 +115,14 @@ def check(file_path: Path, timeout: int = 120) -> dict:
     except subprocess.TimeoutExpired:
         return {
             "okay": False,
+            "has_sorry": False,
             "lean_messages": [{"severity": "error", "data": f"Timed out after {timeout}s", "line": 0, "column": 0}],
             "failed_declarations": [],
         }
     except Exception as e:
         return {
             "okay": False,
+            "has_sorry": False,
             "lean_messages": [{"severity": "error", "data": str(e), "line": 0, "column": 0}],
             "failed_declarations": [],
         }
@@ -105,10 +130,15 @@ def check(file_path: Path, timeout: int = 120) -> dict:
     combined = result.stdout + "\n" + result.stderr
     messages = parse_diagnostics(combined)
     has_error = any(m["severity"] == "error" for m in messages) or result.returncode != 0
+    sorry = has_sorry_warning(messages, combined)
     failed = extract_failed_declarations(messages)
 
+    # Prompts require COMPLETE only when lean_check is okay *and* sorry-free.
+    # Returning okay=true with a sorry warning lets the agent emit COMPLETE
+    # prematurely (and wastes a round when the runner later rejects it).
     return {
-        "okay": not has_error,
+        "okay": not has_error and not sorry,
+        "has_sorry": sorry,
         "lean_messages": messages,
         "failed_declarations": failed,
     }
@@ -122,12 +152,17 @@ def main() -> None:
 
     file_path = args.file.resolve()
     if not file_path.exists():
-        print(json.dumps({"okay": False, "lean_messages": [{"severity": "error", "data": f"File not found: {file_path}", "line": 0, "column": 0}], "failed_declarations": []}), flush=True)
+        print(json.dumps({"okay": False, "has_sorry": False, "lean_messages": [{"severity": "error", "data": f"File not found: {file_path}", "line": 0, "column": 0}], "failed_declarations": []}), flush=True)
         sys.exit(1)
 
     logger.info("lean_check called: file=%s timeout=%d", file_path, args.timeout_seconds)
     result = check(file_path, timeout=args.timeout_seconds)
-    logger.info("lean_check result: okay=%s errors=%d", result["okay"], len([m for m in result["lean_messages"] if m["severity"] == "error"]))
+    logger.info(
+        "lean_check result: okay=%s has_sorry=%s errors=%d",
+        result["okay"],
+        result.get("has_sorry"),
+        len([m for m in result["lean_messages"] if m["severity"] == "error"]),
+    )
 
     print(json.dumps(result, indent=2, ensure_ascii=False), flush=True)
     sys.exit(0 if result["okay"] else 1)

--- a/skills/verification/reference-lean-check.md
+++ b/skills/verification/reference-lean-check.md
@@ -16,7 +16,8 @@ python skills/cli/lean_check.py FILE [OPTIONS]
 ## Output
 
 Returns JSON:
-- `okay` (bool) — whether the file compiled without errors
+- `okay` (bool) — true only when the file compiled with no errors **and** no `declaration uses 'sorry'` warnings (COMPLETE requires both)
+- `has_sorry` (bool) — whether Lean reported a sorry warning on a declaration
 - `lean_messages` — list of errors, warnings, and infos with line numbers (`file_name`, `line`, `column`, `severity`, `data`)
 - `failed_declarations` — list of theorem/definition names that failed
 


### PR DESCRIPTION
## Summary
- Runner `lean_checker` treated any substring `"error"` / `"sorry"` in compiler output as failure. That false-positives on identifiers like `errorMsg` and on non-sorry mentions of the tactic, and is the gate for `COMPLETE` on MiniF2f-style runs.
- Agent-facing `skills/cli/lean_check.py` returned `okay: true` while Lean still emitted `declaration uses 'sorry'`. Prompts require COMPLETE only when check is okay *and* sorry-free, so the agent could emit COMPLETE early (wasting a round when the runner rejects, or landing false COMPLETE if checking is off).
- `find_lean_files` had no `.lake` / `lake-packages` exclusion, so scanning a Lake project root after `lake build` fans out into Mathlib dependency sources.

## Changes
- Classify compiler output via diagnostic severity headers (`error` / `warning`), not raw substrings.
- `lean_check`: `okay = not has_error and not has_sorry`; add `has_sorry` to the JSON; document in the skill reference.
- Skip `.lake`, `lake-packages`, and `.git` path parts in `find_lean_files`.

## Test plan
- [x] Synthetic diagnostics: `errorMsg` warning → no error; real `error:` → error; `declaration uses 'sorry'` → sorry; info mentioning sorry → not sorry
- [x] Temp tree with `.lake/packages/.../B.lean` + project `.lean` files → only project files returned
- [x] `has_sorry_warning` helper true on a parsed sorry warning
- [ ] Maintainer: run `lean_check.py` on a real sorry file under a built Lake project and confirm `okay: false` / `has_sorry: true`


Made with [Cursor](https://cursor.com)